### PR TITLE
Remove font-size styling on html element in home.css

### DIFF
--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,6 +1,6 @@
 html {
   background: #fff;
-  font-size: 18px;
+  /* font-size: 18px; */
 }
 
 .norwex__logo {


### PR DESCRIPTION
So I tried commenting this out, then building the site, then serving it locally and I didn't see the flash in font-size. I think what's happening is you're changing the overall font-size twice.

Once using `typography.js` and once on the `html` element in `home.css`. 

The reason you see the flash is because first, the css from `home.css` loads when the site loads. Then when you scroll down, the JS files load, one of which contains your `typography.js` which changes the font-size.

This is my hunch. I hope you can try this out and see if it fixes it for you! Also, I would look at the [Typography.js Docs](https://kyleamathews.github.io/typography.js/) and look into setting a base-size. It's very similar to what you're doing in `home.css` with the `html` element.